### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Elixir and Erlang
         uses: erlef/setup-beam@v1
@@ -47,7 +47,7 @@ jobs:
   openapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v6 (Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)