### PR TITLE
v0.3.0 — Security Hardening

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "elixirLS.enable": true,
   "elixirLS.elixirPath": "~/.asdf/shims/elixir",
   "elixirLS.erlangPath": "~/.asdf/shims",
   "elixirLS.projectDir": "."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,29 @@ Versioned deliverables tracker for the platform template.
 
 ---
 
+## v0.3.0 — Security Hardening
+
+- [x] Add security headers plug (`X-Content-Type-Options: nosniff`, `Cache-Control: no-store`) on auth endpoints.
+- [x] Add 1MB request body size limit to `Plug.Parsers` (default 8MB is excessive for a JSON API).
+- [x] Add maximum password length validation (128 chars) to prevent bcrypt truncation and CPU exhaustion.
+- [x] Validate OAuth state parameter on callback (signed cookie + `secure_compare`).
+- [x] Configure CORS with explicit allowed origins per environment (dev: localhost, test: all, prod: env var).
+- [x] Wire up rate limiting on login and refresh endpoints (keyed by client IP, 429 + `Retry-After`).
+- [x] Fix: move Bandit `read_timeout` to `runtime.exs` so it isn't overridden.
+- [x] Fix: add `localhost:5173` (Vite) to default CORS origins.
+- [x] 159 tests passing.
+
+---
+
+## v0.2.2 — CORS Support
+
+- [x] Add `cors_plug` dependency and wire `CORSPlug` into endpoint.
+- [x] Configure `CORS_ALLOWED_ORIGINS` env var for production.
+- [x] Fix Dialyzer warnings on ExUnit assertion types.
+- [x] Suppress Bandit idle connection timeout noise in dev.
+
+---
+
 ## v0.2.1 — Bug Fix and Housekeeping
 
 - [x] Fix: logout crashes when no refresh token provided.

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,7 +47,7 @@ config :elixir_api_core, Oban,
 
 # CORS — restrictive default; override in runtime.exs for prod
 config :cors_plug,
-  origin: ["http://localhost:3000"],
+  origin: ["http://localhost:3000", "http://localhost:5173"],
   methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
   headers: ["Authorization", "Content-Type"]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -45,6 +45,12 @@ config :elixir_api_core, Oban,
      ]}
   ]
 
+# CORS — restrictive default; override in runtime.exs for prod
+config :cors_plug,
+  origin: ["http://localhost:3000"],
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+  headers: ["Authorization", "Content-Type"]
+
 # Configure the endpoint
 config :elixir_api_core, ElixirApiCoreWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -19,10 +19,7 @@ config :elixir_api_core, ElixirApiCore.Repo,
 config :elixir_api_core, ElixirApiCoreWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [
-    ip: {127, 0, 0, 1},
-    thousand_island_options: [read_timeout: 300_000]
-  ],
+  http: [ip: {127, 0, 0, 1}],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,8 +20,16 @@ if System.get_env("PHX_SERVER") do
   config :elixir_api_core, ElixirApiCoreWeb.Endpoint, server: true
 end
 
-config :elixir_api_core, ElixirApiCoreWeb.Endpoint,
-  http: [port: String.to_integer(System.get_env("PORT", "4000"))]
+http_opts = [port: String.to_integer(System.get_env("PORT", "4000"))]
+
+http_opts =
+  if config_env() == :dev do
+    Keyword.put(http_opts, :thousand_island_options, read_timeout: 300_000)
+  else
+    http_opts
+  end
+
+config :elixir_api_core, ElixirApiCoreWeb.Endpoint, http: http_opts
 
 if config_env() == :prod do
   database_url =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -79,7 +79,10 @@ if config_env() == :prod do
       origins -> String.split(origins, ",", trim: true)
     end
 
-  config :cors_plug, origin: cors_origins
+  config :cors_plug,
+    origin: cors_origins,
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+    headers: ["Authorization", "Content-Type"]
 
   host = System.get_env("PHX_HOST") || "example.com"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,9 @@ config :elixir_api_core, Oban, testing: :inline
 # Use mock OAuth provider in tests
 config :elixir_api_core, :oauth_provider, ElixirApiCore.Auth.MockOAuthProvider
 
+# Allow all origins in test
+config :cors_plug, origin: ["*"]
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/lib/elixir_api_core/auth.ex
+++ b/lib/elixir_api_core/auth.ex
@@ -11,6 +11,7 @@ defmodule ElixirApiCore.Auth do
   alias ElixirApiCore.Repo
 
   @min_password_length 8
+  @max_password_length 128
 
   @doc """
   Registers a new user with email/password.
@@ -397,6 +398,9 @@ defmodule ElixirApiCore.Auth do
 
       String.length(password) < @min_password_length ->
         {:error, :password_too_short}
+
+      String.length(password) > @max_password_length ->
+        {:error, :password_too_long}
 
       true ->
         {:ok,

--- a/lib/elixir_api_core/auth.ex
+++ b/lib/elixir_api_core/auth.ex
@@ -185,7 +185,10 @@ defmodule ElixirApiCore.Auth do
   """
   def google_authorize_url do
     state = Base.url_encode64(:crypto.strong_rand_bytes(16), padding: false)
-    oauth_provider().authorize_url(state)
+
+    with {:ok, url} <- oauth_provider().authorize_url(state) do
+      {:ok, {url, state}}
+    end
   end
 
   @doc """

--- a/lib/elixir_api_core/auth/cookie.ex
+++ b/lib/elixir_api_core/auth/cookie.ex
@@ -18,6 +18,11 @@ defmodule ElixirApiCore.Auth.Cookie do
     config(:name, "_refresh_token")
   end
 
+  @doc "Returns whether cookies should use the Secure flag."
+  def secure? do
+    config(:secure, false)
+  end
+
   @doc "Returns cookie options for Plug.Conn.put_resp_cookie/4."
   def options do
     [

--- a/lib/elixir_api_core_web/controllers/auth_controller.ex
+++ b/lib/elixir_api_core_web/controllers/auth_controller.ex
@@ -3,6 +3,7 @@ defmodule ElixirApiCoreWeb.AuthController do
 
   alias ElixirApiCore.Auth
   alias ElixirApiCore.Auth.Cookie
+  alias ElixirApiCore.Auth.RateLimits
 
   action_fallback ElixirApiCoreWeb.FallbackController
 
@@ -23,7 +24,8 @@ defmodule ElixirApiCoreWeb.AuthController do
   end
 
   def login(conn, params) do
-    with {:ok, result} <- Auth.login(params) do
+    with {:ok, _remaining} <- RateLimits.check_login(client_ip(conn)),
+         {:ok, result} <- Auth.login(params) do
       conn
       |> put_refresh_cookie(result.refresh_token)
       |> json(%{
@@ -44,7 +46,8 @@ defmodule ElixirApiCoreWeb.AuthController do
   def refresh(conn, params) do
     params = maybe_read_cookie_token(params, conn)
 
-    with {:ok, result} <- Auth.refresh(params) do
+    with {:ok, _remaining} <- RateLimits.check_refresh(client_ip(conn)),
+         {:ok, result} <- Auth.refresh(params) do
       conn
       |> put_refresh_cookie(result.refresh_token)
       |> json(%{
@@ -153,6 +156,10 @@ defmodule ElixirApiCoreWeb.AuthController do
         token -> Map.put(params, "refresh_token", token)
       end
     end
+  end
+
+  defp client_ip(conn) do
+    conn.remote_ip |> :inet.ntoa() |> to_string()
   end
 
   defp verify_oauth_state(conn, params) do

--- a/lib/elixir_api_core_web/controllers/auth_controller.ex
+++ b/lib/elixir_api_core_web/controllers/auth_controller.ex
@@ -66,14 +66,28 @@ defmodule ElixirApiCoreWeb.AuthController do
     end
   end
 
+  @oauth_state_cookie "_oauth_state"
+  @oauth_state_max_age 600
+
   def google_start(conn, _params) do
-    with {:ok, url} <- Auth.google_authorize_url() do
-      json(conn, %{data: %{authorize_url: url}})
+    with {:ok, {url, state}} <- Auth.google_authorize_url() do
+      conn
+      |> put_resp_cookie(@oauth_state_cookie, state,
+        http_only: true,
+        secure: Cookie.secure?(),
+        same_site: "Lax",
+        max_age: @oauth_state_max_age,
+        sign: true
+      )
+      |> json(%{data: %{authorize_url: url}})
     end
   end
 
   def google_callback(conn, params) do
-    with {:ok, result} <- Auth.google_callback(params) do
+    conn = fetch_cookies(conn, signed: [@oauth_state_cookie])
+
+    with :ok <- verify_oauth_state(conn, params),
+         {:ok, result} <- Auth.google_callback(params) do
       status = if Map.has_key?(result, :account), do: :created, else: :ok
 
       data =
@@ -88,6 +102,7 @@ defmodule ElixirApiCoreWeb.AuthController do
         end)
 
       conn
+      |> delete_resp_cookie(@oauth_state_cookie, sign: true)
       |> put_status(status)
       |> put_refresh_cookie(result.refresh_token)
       |> json(%{data: data})
@@ -137,6 +152,17 @@ defmodule ElixirApiCoreWeb.AuthController do
         "" -> params
         token -> Map.put(params, "refresh_token", token)
       end
+    end
+  end
+
+  defp verify_oauth_state(conn, params) do
+    cookie_state = conn.cookies[@oauth_state_cookie]
+    param_state = Map.get(params, "state") || Map.get(params, :state)
+
+    cond do
+      is_nil(cookie_state) or is_nil(param_state) -> {:error, :invalid_oauth_state}
+      Plug.Crypto.secure_compare(cookie_state, param_state) -> :ok
+      true -> {:error, :invalid_oauth_state}
     end
   end
 

--- a/lib/elixir_api_core_web/controllers/fallback_controller.ex
+++ b/lib/elixir_api_core_web/controllers/fallback_controller.ex
@@ -8,6 +8,17 @@ defmodule ElixirApiCoreWeb.FallbackController do
     |> render("validation_error.json", changeset: changeset)
   end
 
+  def call(conn, {:error, {:rate_limited, retry_after}}) do
+    conn
+    |> put_resp_header("retry-after", to_string(retry_after))
+    |> put_status(:too_many_requests)
+    |> put_view(json: ElixirApiCoreWeb.ErrorJSON)
+    |> render("error.json",
+      code: "rate_limited",
+      message: "Too many requests, please try again later"
+    )
+  end
+
   def call(conn, {:error, :invalid_credentials}) do
     conn
     |> put_status(:unauthorized)

--- a/lib/elixir_api_core_web/controllers/fallback_controller.ex
+++ b/lib/elixir_api_core_web/controllers/fallback_controller.ex
@@ -93,6 +93,16 @@ defmodule ElixirApiCoreWeb.FallbackController do
     )
   end
 
+  def call(conn, {:error, :invalid_oauth_state}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(json: ElixirApiCoreWeb.ErrorJSON)
+    |> render("error.json",
+      code: "invalid_oauth_state",
+      message: "Invalid or missing OAuth state parameter"
+    )
+  end
+
   def call(conn, {:error, :google_oauth_not_configured}) do
     conn
     |> put_status(:service_unavailable)

--- a/lib/elixir_api_core_web/controllers/fallback_controller.ex
+++ b/lib/elixir_api_core_web/controllers/fallback_controller.ex
@@ -32,6 +32,16 @@ defmodule ElixirApiCoreWeb.FallbackController do
     )
   end
 
+  def call(conn, {:error, :password_too_long}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: ElixirApiCoreWeb.ErrorJSON)
+    |> render("error.json",
+      code: "password_too_long",
+      message: "Password must be at most 128 characters"
+    )
+  end
+
   def call(conn, {:error, :invalid_refresh_token}) do
     conn
     |> put_status(:unauthorized)

--- a/lib/elixir_api_core_web/endpoint.ex
+++ b/lib/elixir_api_core_web/endpoint.ex
@@ -40,6 +40,7 @@ defmodule ElixirApiCoreWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
+    length: 1_000_000,
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/lib/elixir_api_core_web/plugs/security_headers.ex
+++ b/lib/elixir_api_core_web/plugs/security_headers.ex
@@ -1,0 +1,26 @@
+defmodule ElixirApiCoreWeb.Plugs.SecurityHeaders do
+  @moduledoc """
+  Sets security-related response headers on auth endpoints.
+
+  - `x-content-type-options: nosniff` — prevents browsers from MIME-sniffing
+    the response away from the declared content-type.
+  - `cache-control: no-store` — ensures auth responses (which may contain
+    tokens or user data) are never cached by browsers or proxies.
+
+  ## Usage in router
+
+      pipeline :auth_security do
+        plug ElixirApiCoreWeb.Plugs.SecurityHeaders
+      end
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn
+    |> put_resp_header("x-content-type-options", "nosniff")
+    |> put_resp_header("cache-control", "no-store")
+  end
+end

--- a/lib/elixir_api_core_web/router.ex
+++ b/lib/elixir_api_core_web/router.ex
@@ -5,6 +5,10 @@ defmodule ElixirApiCoreWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :auth_security do
+    plug ElixirApiCoreWeb.Plugs.SecurityHeaders
+  end
+
   pipeline :authenticated do
     plug ElixirApiCoreWeb.Plugs.Auth
     plug ElixirApiCoreWeb.Plugs.RequireAccountScope
@@ -20,7 +24,7 @@ defmodule ElixirApiCoreWeb.Router do
 
   # Public auth endpoints
   scope "/api/v1", ElixirApiCoreWeb do
-    pipe_through :api
+    pipe_through [:api, :auth_security]
 
     post "/auth/register", AuthController, :register
     post "/auth/login", AuthController, :login
@@ -32,7 +36,7 @@ defmodule ElixirApiCoreWeb.Router do
 
   # Authenticated endpoints
   scope "/api/v1", ElixirApiCoreWeb do
-    pipe_through [:api, :authenticated]
+    pipe_through [:api, :auth_security, :authenticated]
 
     post "/auth/switch_account", AuthController, :switch_account
     get "/me", UserController, :me

--- a/test/elixir_api_core/auth/google_oauth_test.exs
+++ b/test/elixir_api_core/auth/google_oauth_test.exs
@@ -6,9 +6,11 @@ defmodule ElixirApiCore.Auth.GoogleOAuthTest do
   import ElixirApiCore.AccountsFixtures
 
   describe "google_authorize_url/0" do
-    test "returns an authorize URL" do
-      assert {:ok, url} = Auth.google_authorize_url()
+    test "returns an authorize URL and state" do
+      assert {:ok, {url, state}} = Auth.google_authorize_url()
       assert url =~ "https://mock.oauth.example.com/authorize?state="
+      assert is_binary(state)
+      assert byte_size(state) > 0
     end
   end
 

--- a/test/elixir_api_core/auth_test.exs
+++ b/test/elixir_api_core/auth_test.exs
@@ -79,6 +79,16 @@ defmodule ElixirApiCore.AuthTest do
     test "returns error when password is too short" do
       assert {:error, :password_too_short} = Auth.register(%{email: "a@b.com", password: "short"})
     end
+
+    test "returns error when password exceeds 128 characters" do
+      long_password = String.duplicate("a", 129)
+      assert {:error, :password_too_long} = Auth.register(%{email: "a@b.com", password: long_password})
+    end
+
+    test "accepts password of exactly 128 characters" do
+      password = String.duplicate("a", 128)
+      assert {:ok, _} = Auth.register(%{email: "max@example.com", password: password})
+    end
   end
 
   describe "login/1" do

--- a/test/elixir_api_core/auth_test.exs
+++ b/test/elixir_api_core/auth_test.exs
@@ -82,7 +82,9 @@ defmodule ElixirApiCore.AuthTest do
 
     test "returns error when password exceeds 128 characters" do
       long_password = String.duplicate("a", 129)
-      assert {:error, :password_too_long} = Auth.register(%{email: "a@b.com", password: long_password})
+
+      assert {:error, :password_too_long} =
+               Auth.register(%{email: "a@b.com", password: long_password})
     end
 
     test "accepts password of exactly 128 characters" do

--- a/test/elixir_api_core_web/controllers/auth_controller_test.exs
+++ b/test/elixir_api_core_web/controllers/auth_controller_test.exs
@@ -43,6 +43,13 @@ defmodule ElixirApiCoreWeb.AuthControllerTest do
       resp = json_response(conn, 422)
       assert resp["error"]["code"] == "password_too_short"
     end
+
+    test "returns error for password exceeding 128 characters", %{conn: conn} do
+      long_password = String.duplicate("a", 129)
+      conn = post(conn, "/api/v1/auth/register", %{email: "a@b.com", password: long_password})
+      resp = json_response(conn, 422)
+      assert resp["error"]["code"] == "password_too_long"
+    end
   end
 
   describe "POST /api/v1/auth/login" do

--- a/test/elixir_api_core_web/controllers/auth_rate_limit_test.exs
+++ b/test/elixir_api_core_web/controllers/auth_rate_limit_test.exs
@@ -1,0 +1,53 @@
+defmodule ElixirApiCoreWeb.AuthRateLimitTest do
+  use ElixirApiCoreWeb.ConnCase, async: false
+
+  alias ElixirApiCore.Auth.RateLimiter
+
+  setup do
+    RateLimiter.reset()
+    :ok
+  end
+
+  describe "POST /api/v1/auth/login rate limiting" do
+    setup %{conn: conn} do
+      post(conn, "/api/v1/auth/register", %{email: "rl@example.com", password: "password123!"})
+      :ok
+    end
+
+    test "returns 429 after exceeding login limit", %{conn: conn} do
+      params = %{email: "rl@example.com", password: "password123!"}
+
+      # Exhaust the 5-request limit
+      for _ <- 1..5 do
+        post(conn, "/api/v1/auth/login", params)
+      end
+
+      # 6th request should be rate limited
+      conn = post(conn, "/api/v1/auth/login", params)
+      resp = json_response(conn, 429)
+
+      assert resp["error"]["code"] == "rate_limited"
+      assert get_resp_header(conn, "retry-after") |> hd() |> String.to_integer() > 0
+    end
+  end
+
+  describe "POST /api/v1/auth/refresh rate limiting" do
+    test "returns 429 after exceeding refresh limit", %{conn: conn} do
+      conn_resp =
+        post(conn, "/api/v1/auth/register", %{email: "rl2@example.com", password: "password123!"})
+
+      %{"data" => %{"refresh_token" => _token}} = json_response(conn_resp, 201)
+
+      # Exhaust the 10-request refresh limit (all will fail with invalid token, but rate limit still counts)
+      for _ <- 1..10 do
+        post(conn, "/api/v1/auth/refresh", %{refresh_token: "bogus_token"})
+      end
+
+      # 11th request should be rate limited
+      conn = post(conn, "/api/v1/auth/refresh", %{refresh_token: "bogus_token"})
+      resp = json_response(conn, 429)
+
+      assert resp["error"]["code"] == "rate_limited"
+    end
+  end
+end

--- a/test/elixir_api_core_web/controllers/google_oauth_controller_test.exs
+++ b/test/elixir_api_core_web/controllers/google_oauth_controller_test.exs
@@ -2,17 +2,33 @@ defmodule ElixirApiCoreWeb.GoogleOAuthControllerTest do
   use ElixirApiCoreWeb.ConnCase, async: true
 
   describe "GET /api/v1/auth/google/start" do
-    test "returns authorize URL", %{conn: conn} do
+    test "returns authorize URL and sets state cookie", %{conn: conn} do
       conn = get(conn, "/api/v1/auth/google/start")
       resp = json_response(conn, 200)
 
       assert resp["data"]["authorize_url"] =~ "https://mock.oauth.example.com/authorize"
+      assert conn.resp_cookies["_oauth_state"]
     end
   end
 
   describe "GET /api/v1/auth/google/callback" do
-    test "creates new user and returns 201 with tokens", %{conn: conn} do
-      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code"})
+    setup %{conn: conn} do
+      # Start the OAuth flow to get a state cookie
+      start_conn = get(conn, "/api/v1/auth/google/start")
+      resp = json_response(start_conn, 200)
+
+      # Extract state from the authorize URL
+      %URI{query: query} = URI.parse(resp["data"]["authorize_url"])
+      %{"state" => state} = URI.decode_query(query)
+
+      # Recycle conn to carry cookies forward
+      conn = recycle(start_conn)
+
+      %{conn: conn, state: state}
+    end
+
+    test "creates new user and returns 201 with tokens", %{conn: conn, state: state} do
+      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: state})
       resp = json_response(conn, 201)
 
       assert resp["data"]["user"]["email"] == "google@example.com"
@@ -21,13 +37,20 @@ defmodule ElixirApiCoreWeb.GoogleOAuthControllerTest do
       assert is_binary(resp["data"]["refresh_token"])
     end
 
-    test "logs in existing google user and returns 200", %{conn: conn} do
+    test "logs in existing google user and returns 200", %{conn: conn, state: state} do
       # First call creates the user
-      get(conn, "/api/v1/auth/google/callback", %{code: "valid_code"})
+      first_conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: state})
+      assert json_response(first_conn, 201)
 
-      # Second call should log in (identity already exists)
-      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code"})
-      resp = json_response(conn, 200)
+      # Start a new OAuth flow for the second callback
+      second_start = get(recycle(first_conn), "/api/v1/auth/google/start")
+      resp = json_response(second_start, 200)
+      %URI{query: query} = URI.parse(resp["data"]["authorize_url"])
+      %{"state" => state2} = URI.decode_query(query)
+
+      conn2 = recycle(second_start)
+      conn2 = get(conn2, "/api/v1/auth/google/callback", %{code: "valid_code", state: state2})
+      resp = json_response(conn2, 200)
 
       assert resp["data"]["user"]["email"] == "google@example.com"
       assert is_binary(resp["data"]["access_token"])
@@ -35,11 +58,42 @@ defmodule ElixirApiCoreWeb.GoogleOAuthControllerTest do
       refute Map.has_key?(resp["data"], "account")
     end
 
-    test "returns 502 for invalid authorization code", %{conn: conn} do
-      conn = get(conn, "/api/v1/auth/google/callback", %{code: "invalid_code"})
+    test "returns 502 for invalid authorization code", %{conn: conn, state: state} do
+      conn = get(conn, "/api/v1/auth/google/callback", %{code: "invalid_code", state: state})
       resp = json_response(conn, 502)
 
       assert resp["error"]["code"] == "oauth_exchange_failed"
+    end
+  end
+
+  describe "GET /api/v1/auth/google/callback — state validation" do
+    test "returns 403 when state param is missing", %{conn: conn} do
+      start_conn = get(conn, "/api/v1/auth/google/start")
+      assert json_response(start_conn, 200)
+
+      conn = recycle(start_conn)
+      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code"})
+      resp = json_response(conn, 403)
+
+      assert resp["error"]["code"] == "invalid_oauth_state"
+    end
+
+    test "returns 403 when state param does not match cookie", %{conn: conn} do
+      start_conn = get(conn, "/api/v1/auth/google/start")
+      assert json_response(start_conn, 200)
+
+      conn = recycle(start_conn)
+      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: "wrong_state"})
+      resp = json_response(conn, 403)
+
+      assert resp["error"]["code"] == "invalid_oauth_state"
+    end
+
+    test "returns 403 when state cookie is missing", %{conn: conn} do
+      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: "some_state"})
+      resp = json_response(conn, 403)
+
+      assert resp["error"]["code"] == "invalid_oauth_state"
     end
   end
 end

--- a/test/elixir_api_core_web/controllers/google_oauth_controller_test.exs
+++ b/test/elixir_api_core_web/controllers/google_oauth_controller_test.exs
@@ -83,7 +83,10 @@ defmodule ElixirApiCoreWeb.GoogleOAuthControllerTest do
       assert json_response(start_conn, 200)
 
       conn = recycle(start_conn)
-      conn = get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: "wrong_state"})
+
+      conn =
+        get(conn, "/api/v1/auth/google/callback", %{code: "valid_code", state: "wrong_state"})
+
       resp = json_response(conn, 403)
 
       assert resp["error"]["code"] == "invalid_oauth_state"

--- a/test/elixir_api_core_web/plugs/security_headers_test.exs
+++ b/test/elixir_api_core_web/plugs/security_headers_test.exs
@@ -3,7 +3,8 @@ defmodule ElixirApiCoreWeb.Plugs.SecurityHeadersTest do
 
   describe "security headers on public auth endpoints" do
     test "POST /auth/register sets security headers", %{conn: conn} do
-      conn = post(conn, "/api/v1/auth/register", %{email: "sh@example.com", password: "password123!"})
+      conn =
+        post(conn, "/api/v1/auth/register", %{email: "sh@example.com", password: "password123!"})
 
       assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
       assert get_resp_header(conn, "cache-control") == ["no-store"]
@@ -12,7 +13,8 @@ defmodule ElixirApiCoreWeb.Plugs.SecurityHeadersTest do
     test "POST /auth/login sets security headers", %{conn: conn} do
       post(conn, "/api/v1/auth/register", %{email: "sh2@example.com", password: "password123!"})
 
-      conn = post(conn, "/api/v1/auth/login", %{email: "sh2@example.com", password: "password123!"})
+      conn =
+        post(conn, "/api/v1/auth/login", %{email: "sh2@example.com", password: "password123!"})
 
       assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
       assert get_resp_header(conn, "cache-control") == ["no-store"]
@@ -28,8 +30,11 @@ defmodule ElixirApiCoreWeb.Plugs.SecurityHeadersTest do
 
   describe "security headers on authenticated auth endpoints" do
     test "POST /auth/switch_account sets security headers", %{conn: conn} do
-      conn_resp = post(conn, "/api/v1/auth/register", %{email: "sh3@example.com", password: "password123!"})
-      %{"data" => %{"access_token" => token, "account" => %{"id" => account_id}}} = json_response(conn_resp, 201)
+      conn_resp =
+        post(conn, "/api/v1/auth/register", %{email: "sh3@example.com", password: "password123!"})
+
+      %{"data" => %{"access_token" => token, "account" => %{"id" => account_id}}} =
+        json_response(conn_resp, 201)
 
       conn =
         conn

--- a/test/elixir_api_core_web/plugs/security_headers_test.exs
+++ b/test/elixir_api_core_web/plugs/security_headers_test.exs
@@ -1,0 +1,52 @@
+defmodule ElixirApiCoreWeb.Plugs.SecurityHeadersTest do
+  use ElixirApiCoreWeb.ConnCase, async: true
+
+  describe "security headers on public auth endpoints" do
+    test "POST /auth/register sets security headers", %{conn: conn} do
+      conn = post(conn, "/api/v1/auth/register", %{email: "sh@example.com", password: "password123!"})
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "POST /auth/login sets security headers", %{conn: conn} do
+      post(conn, "/api/v1/auth/register", %{email: "sh2@example.com", password: "password123!"})
+
+      conn = post(conn, "/api/v1/auth/login", %{email: "sh2@example.com", password: "password123!"})
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "POST /auth/login sets security headers even on failure", %{conn: conn} do
+      conn = post(conn, "/api/v1/auth/login", %{email: "nope@example.com", password: "wrong"})
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+  end
+
+  describe "security headers on authenticated auth endpoints" do
+    test "POST /auth/switch_account sets security headers", %{conn: conn} do
+      conn_resp = post(conn, "/api/v1/auth/register", %{email: "sh3@example.com", password: "password123!"})
+      %{"data" => %{"access_token" => token, "account" => %{"id" => account_id}}} = json_response(conn_resp, 201)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/v1/auth/switch_account", %{account_id: account_id})
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+  end
+
+  describe "health endpoints do NOT get security headers" do
+    test "GET /healthz does not set security headers", %{conn: conn} do
+      conn = get(conn, "/healthz")
+
+      assert get_resp_header(conn, "x-content-type-options") == []
+      assert get_resp_header(conn, "cache-control") != ["no-store"]
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,6 +36,7 @@ defmodule ElixirApiCoreWeb.ConnCase do
 
   setup tags do
     ElixirApiCore.DataCase.setup_sandbox(tags)
+    ElixirApiCore.Auth.RateLimiter.reset()
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 


### PR DESCRIPTION
## Summary

- Add security headers plug (nosniff + no-store) on auth endpoints
- Add 1MB request body size limit to Plug.Parsers
- Add maximum password length validation (128 chars)
- Validate OAuth state parameter on callback (signed cookie + secure_compare)
- Configure CORS with explicit allowed origins per environment
- Wire up rate limiting on login and refresh endpoints (429 + Retry-After)
- Fix: Bandit read_timeout moved to runtime.exs
- Fix: add localhost:5173 to default CORS origins

Closes #15, #16, #17, #18, #19, #20

## Test plan

- [x] 159 tests passing, 0 failures
- [x] Rate limiting returns 429 after exceeding configured limit
- [x] Security headers present on all auth endpoints, absent on health
- [x] OAuth callback rejects missing/mismatched state parameter
- [x] Password > 128 chars rejected with password_too_long
- [x] Request bodies > 1MB rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)