### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirApiCore.MixProject do
   def project do
     [
       app: :elixir_api_core,
-      version: "0.2.0",
+      version: "0.4.0",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Sync `mix.exs` with the v0.4.0 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)